### PR TITLE
Set default linter to ignore comments

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(120L),
-    commented_code_linter = NULL)
+    commented_code_linter = NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,4 @@
 linters: linters_with_defaults(
-    line_length_linter = line_length_linter(120L)
+    line_length_linter = line_length_linter(120L),
+    commented_code_linter = NULL)
   )

--- a/inst/templates/_lintr
+++ b/inst/templates/_lintr
@@ -1,4 +1,4 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(120L),
-    commented_code_linter = NULL)
+    commented_code_linter = NULL
   )

--- a/inst/templates/_lintr
+++ b/inst/templates/_lintr
@@ -1,3 +1,4 @@
 linters: linters_with_defaults(
-    line_length_linter = line_length_linter(120L)
+    line_length_linter = line_length_linter(120L),
+    commented_code_linter = NULL)
   )


### PR DESCRIPTION
For your consideration, based on something @elray1 had mentioned in previous discussions: do we want to ignore comments when linting?