### PR TITLE
Add Air formatting setup to package creation functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubDevs 0.1.1.9000
 
+* `create_hubdev_pkg()` now sets up Air formatting via `usethis::use_air()` (#48).
+* `use_hubdev_pkg_actions()` now includes the `format-check` workflow for Air formatting CI (#48).
 * Remove Hubverse release process overview vignettes (that information has moved
   to the [Hubverse documentation](https://docs.hubverse.io/en/latest/developer/)).
 

--- a/R/create_hubdev_pkg.R
+++ b/R/create_hubdev_pkg.R
@@ -39,6 +39,9 @@ create_hubdev_pkg <- function(
   # Create community documents
   use_hubdev_community()
 
+  # Set up Air formatting
+  usethis::use_air()
+
   usethis::use_git()
   usethis::use_git_hook(
     "pre-commit",

--- a/R/use_hubdev_pkg_actions.R
+++ b/R/use_hubdev_pkg_actions.R
@@ -8,6 +8,8 @@
 #' https://github.com/r-lib/actions/blob/v2-branch/examples/test-coverage.yaml)
 #'    - linting with `lintr` [(`lint`)](
 #' https://github.com/r-lib/actions/blob/v2-branch/examples/lint.yaml)
+#'    - Air format checking [(`format-check`)](
+#' https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml)
 #'
 #' @export
 use_hubdev_pkg_actions <- function() {
@@ -15,4 +17,7 @@ use_hubdev_pkg_actions <- function() {
   usethis::use_github_action("test-coverage")
   usethis::use_github_action("lint")
   use_hubdev_lintr()
+  usethis::use_github_action(
+    url = "https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml"
+  )
 }

--- a/man/use_hubdev_pkg_actions.Rd
+++ b/man/use_hubdev_pkg_actions.Rd
@@ -13,5 +13,6 @@ Downloads standard r-lib GitHub Action workflows and writes them to the
 \item standard R CMD CHECK \href{https://github.com/r-lib/actions/blob/v2-branch/examples/check-standard.yaml}{(\code{check-standard})}
 \item test coverage \href{https://github.com/r-lib/actions/blob/v2-branch/examples/test-coverage.yaml}{(\code{test-coverage})}
 \item linting with \code{lintr} \href{https://github.com/r-lib/actions/blob/v2-branch/examples/lint.yaml}{(\code{lint})}
+\item Air format checking \href{https://github.com/posit-dev/setup-air/blob/main/examples/format-check.yaml}{(\code{format-check})}
 }
 }

--- a/tests/testthat/_snaps/create_hubdev_pkg.md
+++ b/tests/testthat/_snaps/create_hubdev_pkg.md
@@ -6,10 +6,11 @@
       testPkg/DESCRIPTION          testPkg/LICENSE              
       testPkg/LICENSE.md           testPkg/NAMESPACE            
       testPkg/R                    testPkg/README.Rmd           
-      testPkg/README.md            testPkg/man                  
-      testPkg/man/figures          testPkg/man/figures/logo.png 
-      testPkg/testPkg.Rproj        testPkg/tests                
-      testPkg/tests/testthat       testPkg/tests/testthat.R     
+      testPkg/README.md            testPkg/air.toml             
+      testPkg/man                  testPkg/man/figures          
+      testPkg/man/figures/logo.png testPkg/testPkg.Rproj        
+      testPkg/tests                testPkg/tests/testthat       
+      testPkg/tests/testthat.R     
 
 ---
 
@@ -110,4 +111,5 @@
        [4] "^\\.Rhistory$"     "^\\.Rdata$"        "^\\.httr-oauth$"  
        [7] "^\\.secrets$"      "^\\.claude$"       "^claude\\.md$"    
       [10] "^LICENSE\\.md$"    "^README\\.Rmd$"    "^\\.github$"      
+      [13] "^[.]?air[.]toml$"  "^\\.vscode$"      
 

--- a/tests/testthat/test-use_hubdev_github.R
+++ b/tests/testthat/test-use_hubdev_github.R
@@ -25,7 +25,12 @@ test_that("use_hubdev_pkg_actions works", {
 
   expect_equal(
     workflow_files,
-    c("R-CMD-check.yaml", "lint.yaml", "test-coverage.yaml")
+    c(
+      "R-CMD-check.yaml",
+      "format-check.yaml",
+      "lint.yaml",
+      "test-coverage.yaml"
+    )
   )
 })
 


### PR DESCRIPTION
> [!NOTE]
> This PR needs rebasing with main after #49 is merged before merging.
> 
> **Tip for reviewers:** For a cleaner review, use the commit dropdown in the "Files changed" tab to select only the latest commit.

## Summary

- Add `usethis::use_air()` call to `create_hubdev_pkg()` to set up Air formatting for new packages
- Add `format-check` workflow to `use_hubdev_pkg_actions()` via setup-air URL
- Update tests and snapshots accordingly

Closes #48