### PR TITLE
Fix r-universe builds and update templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Config/Needs/website: hubverse-org/hubStyle
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Language: en-US

--- a/R/create_hubdev_pkg.R
+++ b/R/create_hubdev_pkg.R
@@ -7,6 +7,7 @@
 #' to create repositories in the hubverse organisation.
 #' @param hubdocs_contribute_url Character string. URL of the general contributing
 #' information page on hubDocs.
+#' @inheritParams use_hubdev_readme
 #'
 #' @return Path to the newly created project or package, invisibly.
 #' @export
@@ -15,7 +16,8 @@ create_hubdev_pkg <- function(
   fields = list(),
   copyright_holder = "Consortium of Infectious Disease Modeling Hubs",
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/community/"
+  hubdocs_contribute_url = "https://hubverse.io/community/",
+  build = TRUE
 ) {
   path <- usethis::create_package(
     path,
@@ -33,7 +35,8 @@ create_hubdev_pkg <- function(
 
   use_hubdev_readme(
     organisation = organisation,
-    hubdocs_contribute_url = hubdocs_contribute_url
+    hubdocs_contribute_url = hubdocs_contribute_url,
+    build = build
   )
 
   # Create community documents

--- a/R/use_hubdev_readme.R
+++ b/R/use_hubdev_readme.R
@@ -1,10 +1,13 @@
 #' Create a basic hubverse README.Rmd from template
 #'
 #' @inheritParams create_hubdev_pkg
+#' @param build Logical. Whether to build the README.md from README.Rmd.
+#'   Defaults to `TRUE`.
 #' @export
 use_hubdev_readme <- function(
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/community/"
+  hubdocs_contribute_url = "https://hubverse.io/community/",
+  build = TRUE
 ) {
   rlang::check_installed("rmarkdown")
 
@@ -25,5 +28,7 @@ use_hubdev_readme <- function(
 
   usethis::use_lifecycle_badge("experimental")
   usethis::use_cran_badge()
-  devtools::build_readme()
+  if (build) {
+    devtools::build_readme()
+  }
 }

--- a/inst/templates/_lintr
+++ b/inst/templates/_lintr
@@ -1,4 +1,5 @@
 linters: linters_with_defaults(
     line_length_linter = line_length_linter(120L),
-    commented_code_linter = NULL
+    commented_code_linter = NULL,
+    indentation_linter = NULL
   )

--- a/inst/templates/_pkgdown.yml
+++ b/inst/templates/_pkgdown.yml
@@ -1,3 +1,5 @@
 url: https://{{{ organisation }}}.github.io/{{{ pkgname }}}/
 template:
   package: hubStyle
+development:
+  mode: auto

--- a/man/create_hubdev_pkg.Rd
+++ b/man/create_hubdev_pkg.Rd
@@ -9,7 +9,8 @@ create_hubdev_pkg(
   fields = list(),
   copyright_holder = "Consortium of Infectious Disease Modeling Hubs",
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/community/"
+  hubdocs_contribute_url = "https://hubverse.io/community/",
+  build = TRUE
 )
 }
 \arguments{
@@ -30,6 +31,9 @@ to create repositories in the hubverse organisation.}
 
 \item{hubdocs_contribute_url}{Character string. URL of the general contributing
 information page on hubDocs.}
+
+\item{build}{Logical. Whether to build the README.md from README.Rmd.
+Defaults to \code{TRUE}.}
 }
 \value{
 Path to the newly created project or package, invisibly.

--- a/man/use_hubdev_pkgdown.Rd
+++ b/man/use_hubdev_pkgdown.Rd
@@ -13,8 +13,8 @@ use_hubdev_pkgdown(add_logo = FALSE)
 The function performs a number of actions to configure a hubverse package's
 pkgdown site to use the \code{hubStyle} template for docs styling.
 \itemize{
-\item Runs \code{\link[=use_pkgdown]{use_pkgdown()}} to initialise pkgdown documentation.
-\item Runs \code{\link[=use_github_pages]{use_github_pages()}} to initialise GitHub Pages for the package.
+\item Runs \code{\link[usethis:use_pkgdown]{usethis::use_pkgdown()}} to initialise pkgdown documentation.
+\item Runs \code{\link[usethis:use_github_pages]{usethis::use_github_pages()}} to initialise GitHub Pages for the package.
 \item Adds a GitHub Action workflow for building pkgdown documentation and deploying
 to GitHub Pages (productions) and Netlify (PR previews) using
 \code{use_hubdev_pkgdown_action()}.

--- a/man/use_hubdev_readme.Rd
+++ b/man/use_hubdev_readme.Rd
@@ -6,7 +6,8 @@
 \usage{
 use_hubdev_readme(
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/community/"
+  hubdocs_contribute_url = "https://hubverse.io/community/",
+  build = TRUE
 )
 }
 \arguments{
@@ -16,6 +17,9 @@ to create repositories in the hubverse organisation.}
 
 \item{hubdocs_contribute_url}{Character string. URL of the general contributing
 information page on hubDocs.}
+
+\item{build}{Logical. Whether to build the README.md from README.Rmd.
+Defaults to \code{TRUE}.}
 }
 \description{
 Create a basic hubverse README.Rmd from template

--- a/tests/testthat/_snaps/create_hubdev_pkg.md
+++ b/tests/testthat/_snaps/create_hubdev_pkg.md
@@ -6,11 +6,10 @@
       testPkg/DESCRIPTION          testPkg/LICENSE              
       testPkg/LICENSE.md           testPkg/NAMESPACE            
       testPkg/R                    testPkg/README.Rmd           
-      testPkg/README.md            testPkg/air.toml             
-      testPkg/man                  testPkg/man/figures          
-      testPkg/man/figures/logo.png testPkg/testPkg.Rproj        
-      testPkg/tests                testPkg/tests/testthat       
-      testPkg/tests/testthat.R     
+      testPkg/air.toml             testPkg/man                  
+      testPkg/man/figures          testPkg/man/figures/logo.png 
+      testPkg/testPkg.Rproj        testPkg/tests                
+      testPkg/tests/testthat       testPkg/tests/testthat.R     
 
 ---
 

--- a/tests/testthat/test-create_hubdev_pkg.R
+++ b/tests/testthat/test-create_hubdev_pkg.R
@@ -2,7 +2,7 @@ test_that("create_hubdev_pkg works", {
   temp_dir <- tempdir()
   pkg_path <- file.path(temp_dir, "testPkg")
 
-  suppressMessages(create_hubdev_pkg(pkg_path))
+  suppressMessages(create_hubdev_pkg(pkg_path, build = FALSE))
 
   # Check basic structure
   visible_files <- fs::dir_ls(pkg_path, recurse = TRUE) |>

--- a/tests/testthat/test-use_hubdev_github.R
+++ b/tests/testthat/test-use_hubdev_github.R
@@ -2,7 +2,7 @@ test_that("use_hubdev_pkg_actions works", {
   temp_dir <- tempdir()
   pkg_path <- file.path(temp_dir, "testPkg")
 
-  suppressMessages(create_hubdev_pkg(pkg_path))
+  suppressMessages(create_hubdev_pkg(pkg_path, build = FALSE))
 
   current_wd <- getwd()
   setwd(pkg_path)
@@ -39,7 +39,7 @@ test_that("use_hubdev_pkgdown works", {
   temp_dir <- tempdir()
   pkg_path <- file.path(temp_dir, "testPkg")
 
-  suppressMessages(create_hubdev_pkg(pkg_path))
+  suppressMessages(create_hubdev_pkg(pkg_path, build = FALSE))
 
   current_wd <- getwd()
   setwd(pkg_path)
@@ -60,7 +60,7 @@ test_that("use_hubdev_pkgdown_action works", {
   temp_dir <- tempdir()
   pkg_path <- file.path(temp_dir, "testPkg")
 
-  suppressMessages(create_hubdev_pkg(pkg_path))
+  suppressMessages(create_hubdev_pkg(pkg_path, build = FALSE))
 
   current_wd <- getwd()
   setwd(pkg_path)


### PR DESCRIPTION
## Summary

- **#54** — Add `development: mode: auto` to `_pkgdown.yml` template so pkgdown builds dev versions into `docs/dev/`
- **#55** — Disable `indentation_linter` in `.lintr` template to avoid conflicts with Air formatting
- **#56** — Add `build` parameter to `use_hubdev_readme()` / `create_hubdev_pkg()` to skip `devtools::build_readme()` during R CMD check, which was failing because `pak::local_install_deps()` can't run in constrained build environments (e.g. r-universe)

Closes #54, closes #55, closes #56

## Test plan

- [x] All 16 existing tests pass locally with `devtools::test()`
- [x] Snapshot updated to reflect `README.md` no longer being generated during tests
- [ ] After merge and release, verify r-universe builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)