### PR TITLE
Release hubDevs v1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubDevs
 Title: Utilities for Creating and Standardising Hubverse Packages
-Version: 1.0.0.9000
+Version: 1.1.0
 Authors@R: c(
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-# hubDevs (development version)
+# hubDevs 1.1.0
+
+* Add `development: mode: auto` to `_pkgdown.yml` template so pkgdown builds
+  dev documentation into `docs/dev/` (#54).
+* Disable `indentation_linter` in `.lintr` template to avoid conflicts with Air
+  formatting (#55).
+* Add `build` parameter to `use_hubdev_readme()` and `create_hubdev_pkg()` to
+  allow skipping `devtools::build_readme()`, fixing r-universe build failures
+  (#56).
 
 # hubDevs 1.0.0
 


### PR DESCRIPTION
## Summary

- Add `development: mode: auto` to `_pkgdown.yml` template so pkgdown builds dev documentation into `docs/dev/` (#54)
- Disable `indentation_linter` in `.lintr` template to avoid conflicts with Air formatting (#55)
- Add `build` parameter to `use_hubdev_readme()` and `create_hubdev_pkg()` to allow skipping `devtools::build_readme()`, fixing r-universe build failures (#56)