### PR TITLE
Set development version to 1.1.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubDevs
 Title: Utilities for Creating and Standardising Hubverse Packages
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubDevs (development version)
+
 # hubDevs 1.1.0
 
 * Add `development: mode: auto` to `_pkgdown.yml` template so pkgdown builds


### PR DESCRIPTION
## Summary

- Bump version to 1.1.0.9000 after v1.1.0 release
- Add development heading to NEWS.md